### PR TITLE
Schema deployment v1

### DIFF
--- a/.github/workflows/manual-schema-test.yml
+++ b/.github/workflows/manual-schema-test.yml
@@ -52,15 +52,14 @@ jobs:
       - name: Install ajv-cli and formats
         run: npm install -g ajv-cli ajv-formats
 
-      - name: Validate package schema
+      - name: Validate schemas
         run: |
-          echo "Validating package schema..."
-          ajv compile -s package/${{ github.event.inputs.pkg_schema_version }}/hatch_pkg_metadata_schema.json --spec=draft7 -c ajv-formats
-
-      - name: Validate registry schema
-        run: |
-          echo "Validating registry schema..."
-          ajv compile -s registry/${{ github.event.inputs.registry_schema_version }}/hatch_all_pkg_metadata_schema.json --spec=draft7 -c ajv-formats
+          # Make scripts executable
+          chmod +x ./scripts/validate_schemas.sh
+          
+          # Run validation on the specified schema versions
+          echo "Validating schemas..."
+          ./scripts/validate_schemas.sh "${{ github.event.inputs.pkg_schema_version }}" "${{ github.event.inputs.registry_schema_version }}"
 
   test-deployment:
     if: ${{ github.event.inputs.deploy_test == 'true' }}
@@ -74,93 +73,62 @@ jobs:
 
       - name: Set test artifact version
         run: |
-          echo "TEST_VERSION=test-$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
+          echo "TEST_ID=test-$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
           echo "TEST_PKG_VERSION=${{ github.event.inputs.pkg_schema_version }}" >> $GITHUB_ENV
           echo "TEST_REG_VERSION=${{ github.event.inputs.registry_schema_version }}" >> $GITHUB_ENV
+          
+          # Create JSON arrays for each schema type
+          echo "PKG_VERSIONS_JSON=[\"${{ github.event.inputs.pkg_schema_version }}\"]" >> $GITHUB_ENV
+          echo "REG_VERSIONS_JSON=[\"${{ github.event.inputs.registry_schema_version }}\"]" >> $GITHUB_ENV
 
       - name: Package schemas for test release
         run: |
-          mkdir -p artifacts/${{ env.TEST_VERSION }}
+          # Make scripts executable
+          chmod +x ./scripts/package_schemas.sh
           
-          # Copy schemas to versioned directory
-          cp -r package artifacts/${{ env.TEST_VERSION }}/
-          cp -r registry artifacts/${{ env.TEST_VERSION }}/
+          # Create artifacts directory
+          mkdir -p artifacts
           
-          # Create metadata file for test version
-          echo "{\"version\": \"${{ env.TEST_VERSION }}\", \"test_date\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\", \"commit\": \"${{ github.sha }}\"}" > artifacts/${{ env.TEST_VERSION }}/metadata.json
+          # Use the package_schemas.sh script to package the schemas
+          echo "Packaging schemas for testing..."
+          ./scripts/package_schemas.sh ./artifacts "$PKG_VERSIONS_JSON" "$REG_VERSIONS_JSON" "${{ github.sha }}"
           
-          # Create version-specific zip for release
-          cd artifacts
-          zip -r "schemas-${{ env.TEST_VERSION }}.zip" ${{ env.TEST_VERSION }}
-          cd ..
+          # Add test ID to the zip filenames
+          if [ ! -z "$TEST_PKG_VERSION" ]; then
+            mv artifacts/package/schemas-package-$TEST_PKG_VERSION.zip artifacts/package/schemas-package-$TEST_PKG_VERSION-$TEST_ID.zip
+          fi
+          
+          if [ ! -z "$TEST_REG_VERSION" ]; then
+            mv artifacts/registry/schemas-registry-$TEST_REG_VERSION.zip artifacts/registry/schemas-registry-$TEST_REG_VERSION-$TEST_ID.zip
+          fi
 
       - name: Upload test artifacts to workflow
         uses: actions/upload-artifact@v4
         with:
-          name: schemas-${{ env.TEST_VERSION }}
-          path: artifacts/schemas-${{ env.TEST_VERSION }}.zip
+          name: schemas-test-${{ env.TEST_ID }}
+          path: artifacts/
           retention-days: 3
-
-      - name: Test GitHub Release process
-        if: false  # Disabled by default to prevent creating actual GitHub releases during test
-        run: |
-          echo "Would create a GitHub release with tag 'schemas-${{ env.TEST_VERSION }}'"
-          echo "Release title: Test Schema Release ${{ env.TEST_VERSION }}"
-          echo "Release asset: artifacts/schemas-${{ env.TEST_VERSION }}.zip"
-          
-          # This is commented out to prevent actual release creation during tests
-          # Uncomment to test actual release creation (requires permissions)
-          # gh release create "schemas-${{ env.TEST_VERSION }}" \
-          #   --title "Test Schema Release ${{ env.TEST_VERSION }}" \
-          #   --notes "Test schema release created on $(date -u +"%Y-%m-%d"). DO NOT USE IN PRODUCTION." \
-          #   --prerelease \
-          #   "artifacts/schemas-${{ env.TEST_VERSION }}.zip"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test GitHub Pages deployment
         run: |
+          # Make scripts executable
+          chmod +x ./scripts/generate_gh_pages.sh
+          
+          # Create directory for test GitHub Pages content
           mkdir -p test-gh-pages-content
           
-          # Create a test index.html that would redirect to the test version
-          cat > test-gh-pages-content/test-index.html << EOF
-          <!DOCTYPE html>
-          <html>
-            <head>
-              <meta charset="UTF-8">
-              <title>CrackingShells Schemas - TEST</title>
-              <meta http-equiv="refresh" content="0; url=https://github.com/${{ github.repository }}/releases/download/schemas-${{ env.TEST_VERSION }}/schemas-${{ env.TEST_VERSION }}.zip">
-            </head>
-            <body>
-              <h1>CrackingShells Schemas - TEST ENVIRONMENT</h1>
-              <p>This is a test redirect to version ${{ env.TEST_VERSION }}. Do not use in production.</p>
-              <p><a href="https://github.com/${{ github.repository }}/releases/download/schemas-${{ env.TEST_VERSION }}/schemas-${{ env.TEST_VERSION }}.zip">Click here for the test schema package</a></p>
-            </body>
-          </html>
-          EOF
+          # Use our script to generate test GitHub Pages content
+          echo "Generating test GitHub Pages content..."
+          ./scripts/generate_gh_pages.sh ./test-gh-pages-content "$TEST_PKG_VERSION" "$TEST_REG_VERSION" "${{ github.repository }}"
           
-          # Create a test JSON file with version information for API consumers
-          cat > test-gh-pages-content/test-latest.json << EOF
-          {
-            "latest_version": "${{ env.TEST_VERSION }}",
-            "release_url": "https://github.com/${{ github.repository }}/releases/tag/schemas-${{ env.TEST_VERSION }}",
-            "download_url": "https://github.com/${{ github.repository }}/releases/download/schemas-${{ env.TEST_VERSION }}/schemas-${{ env.TEST_VERSION }}.zip",
-            "schema_urls": {
-              "package": "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.inputs.tested_branch }}/package/${{ env.TEST_PKG_VERSION }}/hatch_pkg_metadata_schema.json",
-              "registry": "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.inputs.tested_branch }}/registry/${{ env.TEST_REG_VERSION }}/hatch_all_pkg_metadata_schema.json"
-            },
-            "updated_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-            "is_test": true
-          }
-          EOF
-          
-          # Upload the test GitHub Pages content as artifacts
-          echo "Test GitHub Pages content would be deployed to gh-pages branch"
+          # Add test indicator to the generated content
+          sed -i 's/<h1>Hatch Schemas<\/h1>/<h1>Hatch Schemas - TEST ENVIRONMENT<\/h1>/g' ./test-gh-pages-content/index.html
+          jq '. += {"is_test": true, "test_id": "'"$TEST_ID"'"}' ./test-gh-pages-content/latest.json > ./test-gh-pages-content/latest.json.tmp && mv ./test-gh-pages-content/latest.json.tmp ./test-gh-pages-content/latest.json
 
       - name: Upload test GitHub Pages content
         uses: actions/upload-artifact@v4
         with:
-          name: test-gh-pages-content
+          name: test-gh-pages-content-${{ env.TEST_ID }}
           path: test-gh-pages-content/
           retention-days: 3
 
@@ -168,13 +136,18 @@ jobs:
         run: |
           echo "Test deployment URLs:"
           echo ""
-          echo "Test GitHub Release:"
-          echo "- ZIP: https://github.com/${{ github.repository }}/releases/download/schemas-${{ env.TEST_VERSION }}/schemas-${{ env.TEST_VERSION }}.zip (simulated)"
+          
+          if [ ! -z "$TEST_PKG_VERSION" ]; then
+            echo "Test Package Schema:"
+            echo "- ZIP: artifacts/package/schemas-package-$TEST_PKG_VERSION-$TEST_ID.zip (simulated)"
+            echo "- JSON: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.inputs.tested_branch }}/package/$TEST_PKG_VERSION/hatch_pkg_metadata_schema.json"
+          fi
+          
+          if [ ! -z "$TEST_REG_VERSION" ]; then
+            echo "Test Registry Schema:"
+            echo "- ZIP: artifacts/registry/schemas-registry-$TEST_REG_VERSION-$TEST_ID.zip (simulated)"
+            echo "- JSON: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.inputs.tested_branch }}/registry/$TEST_REG_VERSION/hatch_all_pkg_metadata_schema.json"
+          fi
+          
           echo ""
-          echo "Test GitHub Pages:"
-          echo "- Web: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/test-index.html (simulated)"
-          echo "- API: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/test-latest.json (simulated)"
-          echo ""
-          echo "Direct schema URLs:"
-          echo "- Package: https://raw.githubusercontent.com/${{ github.repository }}/main/package/${{ env.TEST_PKG_VERSION }}/hatch_pkg_metadata_schema.json"
-          echo "- Registry: https://raw.githubusercontent.com/${{ github.repository }}/main/registry/${{ env.TEST_REG_VERSION }}/hatch_all_pkg_metadata_schema.json"
+          echo "Test GitHub Pages content available in workflow artifacts"

--- a/.github/workflows/schema-deployment.yml
+++ b/.github/workflows/schema-deployment.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - 'package/v*/**'
       - 'registry/v*/**'
-      - '.github/workflow/schema-deployment.yml'
+      - '.github/workflows/schema-deployment.yml'
   pull_request:
     branches:
       - main
@@ -15,6 +15,22 @@ on:
       - 'package/v*/**'
       - 'registry/v*/**'
   workflow_dispatch: # Allows manual triggering of the workflow
+    inputs:
+      force:
+        description: 'Force deployment even if no changes detected'
+        type: boolean
+        required: true
+        default: false
+      pkg_schema_version:
+        description: 'Package schema version'
+        type: string
+        required: false
+        default: 'v1'
+      registry_schema_version:
+        description: 'Registry schema version'
+        type: string
+        required: false
+        default: 'v1'
 
 permissions:
   contents: write    # For GitHub Releases
@@ -30,8 +46,10 @@ jobs:
   detect-versions:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.get-versions.outputs.versions }}
-      highest_version: ${{ steps.get-versions.outputs.highest_version }}
+      pkg_versions: ${{ steps.get-versions.outputs.pkg_versions }}
+      registry_versions: ${{ steps.get-versions.outputs.registry_versions }}
+      highest_pkg_version: ${{ steps.get-versions.outputs.highest_pkg_version }}
+      highest_registry_version: ${{ steps.get-versions.outputs.highest_registry_version }}
       changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
     steps:
       - name: Checkout repository
@@ -47,42 +65,28 @@ jobs:
             package/v*/**
             registry/v*/**
 
-      - name: Detect version changes
+      - name: Detect versions from changed files
         id: get-versions
         run: |
-          # Find all distinct versions in changed files
-          VERSION_PATTERN='(v[0-9]+(\.[0-9]+)*)'
-          VERSIONS=()
+          # Make scripts executable
+          chmod +x ./scripts/detect_versions.sh
           
-          echo "Changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
+          # Use the script to detect versions from changed files
+          echo "Running version detection..."
           
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            if [[ $file =~ $VERSION_PATTERN ]]; then
-              VERSIONS+=("${BASH_REMATCH[1]}")
-            fi
-          done
-          
-          # Get unique versions
-          UNIQUE_VERSIONS=($(echo "${VERSIONS[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
-          
-          # Sort versions to find the highest
-          if [[ ${#UNIQUE_VERSIONS[@]} -gt 0 ]]; then
-            IFS=$'\n' SORTED=($(sort -Vr <<<"${UNIQUE_VERSIONS[*]}"))
-            unset IFS
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.force }}" == "true" ]]; then
+            echo "Force deployment enabled. Using provided versions."
+            PKG_VERSION="${{ github.event.inputs.pkg_schema_version }}"
+            REG_VERSION="${{ github.event.inputs.registry_schema_version }}"
             
-            # Join unique versions as a JSON array for output
-            VERSIONS_JSON="[\"$(echo "${UNIQUE_VERSIONS[@]}" | sed 's/ /\", \"/g')\"]"
-            echo "versions=${VERSIONS_JSON}" >> $GITHUB_OUTPUT
-            echo "highest_version=${SORTED[0]}" >> $GITHUB_OUTPUT
-            
-            echo "Detected versions: ${UNIQUE_VERSIONS[*]}"
-            echo "Highest version: ${SORTED[0]}"
+            # Create JSON arrays for each schema type
+            echo "pkg_versions=[\"$PKG_VERSION\"]" >> $GITHUB_OUTPUT
+            echo "registry_versions=[\"$REG_VERSION\"]" >> $GITHUB_OUTPUT
+            echo "highest_pkg_version=$PKG_VERSION" >> $GITHUB_OUTPUT
+            echo "highest_registry_version=$REG_VERSION" >> $GITHUB_OUTPUT
           else
-            echo "No version pattern detected in changed files"
-            echo "versions=[]" >> $GITHUB_OUTPUT
-            echo "highest_version=" >> $GITHUB_OUTPUT
-            echo "::warning::No schema versions detected in changed files. Stopping workflow."
-            exit 0  # Gracefully exit the workflow
+            # Process changed files to detect versions
+            ./scripts/detect_versions.sh ${{ steps.changed-files.outputs.all_changed_files }}
           fi
 
   validate-schemas:
@@ -100,75 +104,49 @@ jobs:
       - name: Install ajv-cli and formats
         run: npm install -g ajv-cli ajv-formats
 
-      - name: Validate package schema
+      - name: Validate schemas
         run: |
-          echo "Validating package schema..."
-          ajv compile -s package/${{ steps.detect-versions.outputs.highest_version }}/hatch_pkg_metadata_schema.json --spec=draft7 -c ajv-formats
-
-      - name: Validate registry schema
-        run: |
-          echo "Validating registry schema..."
-          ajv compile -s registry/${{ steps.detect-versions.outputs.highest_version }}/hatch_all_pkg_metadata_schema.json --spec=draft7 -c ajv-formats
+          # Make scripts executable
+          chmod +x ./scripts/validate_schemas.sh
+          
+          # Run validation on the detected schema versions
+          echo "Running schema validation..."
+          ./scripts/validate_schemas.sh "${{ needs.detect-versions.outputs.highest_pkg_version }}" "${{ needs.detect-versions.outputs.highest_registry_version }}"
 
   build-deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [detect-versions, validate-schemas]
     runs-on: ubuntu-latest
     env:
-      VERSIONS: ${{ needs.detect-versions.outputs.versions }}
-      HIGHEST_VERSION: ${{ needs.detect-versions.outputs.highest_version }}
+      PKG_VERSIONS: ${{ needs.detect-versions.outputs.pkg_versions }}
+      REGISTRY_VERSIONS: ${{ needs.detect-versions.outputs.registry_versions }}
+      HIGHEST_PKG_VERSION: ${{ needs.detect-versions.outputs.highest_pkg_version }}
+      HIGHEST_REGISTRY_VERSION: ${{ needs.detect-versions.outputs.highest_registry_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Parse versions
+      - name: Display version information
         run: | 
-          echo "Deploying versions: $VERSIONS with highest version: $HIGHEST_VERSION"
+          echo "Deploying package versions: $PKG_VERSIONS with highest package version: $HIGHEST_PKG_VERSION"
+          echo "Deploying registry versions: $REGISTRY_VERSIONS with highest registry version: $HIGHEST_REGISTRY_VERSION"
 
-      - name: Package schemas for all versions
+      - name: Package schemas
         run: |
-          mkdir -p artifacts
+          # Make scripts executable
+          chmod +x ./scripts/package_schemas.sh
           
-          # Get the versions as an array
-          VERSIONS_ARRAY=$(echo $VERSIONS | jq -r '.[]')
-          
-          # Loop through each version
-          for VERSION in $VERSIONS_ARRAY; do
-            echo "Processing version: $VERSION"
-            mkdir -p artifacts/$VERSION
-            
-            # Copy schemas to versioned directory
-            cp -r package artifacts/$VERSION/
-            cp -r registry artifacts/$VERSION/
-            
-            # Create metadata files for each version
-            echo "{\"version\": \"$VERSION\", \"build_date\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\", \"commit\": \"${{ github.sha }}\"}" > artifacts/$VERSION/metadata.json
-            
-            # Create version-specific zip for release
-            cd artifacts
-            zip -r "schemas-$VERSION.zip" $VERSION
-            cd ..
-          done
+          # Package schemas using the package_schemas.sh script
+          echo "Packaging schemas for release..."
+          ./scripts/package_schemas.sh ./artifacts "$PKG_VERSIONS" "$REGISTRY_VERSIONS" "${{ github.sha }}"
 
-      # Create GitHub Release for each version 
-      - name: Create GitHub Releases
+      - name: Create GitHub releases
         run: |
-          # Get the versions as an array
-          VERSIONS_ARRAY=$(echo $VERSIONS | jq -r '.[]')
+          # Make scripts executable
+          chmod +x ./scripts/create_releases.sh
           
-          # Process each version
-          for VERSION in $VERSIONS_ARRAY; do
-            echo "Creating release for version: $VERSION"
-            
-            # Get release asset path
-            ASSET_PATH="artifacts/schemas-$VERSION.zip"
-            
-            # Create a GitHub release using GitHub CLI
-            gh release create "schemas-$VERSION" \
-              --title "Schema Release $VERSION" \
-              --notes "Schema version $VERSION released on $(date -u +"%Y-%m-%d")" \
-              "$ASSET_PATH"
-          done
+          # Create releases using the create_releases.sh script
+          echo "Creating GitHub releases..."
+          ./scripts/create_releases.sh ./artifacts "$PKG_VERSIONS" "$REGISTRY_VERSIONS"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -178,40 +156,14 @@ jobs:
         uses: actions/configure-pages@v5
 
       # Update the "latest" pointer in a minimal GitHub Pages site
-      - name: Prepare latest pointer for GitHub Pages
+      - name: Prepare GitHub Pages content
         run: |
-          mkdir -p gh-pages-content
+          # Make scripts executable
+          chmod +x ./scripts/generate_gh_pages.sh
           
-          # Create an index.html that redirects to the highest version
-          cat > gh-pages-content/index.html << EOF
-          <!DOCTYPE html>
-          <html>
-            <head>
-              <meta charset="UTF-8">
-              <title>CrackingShells Schemas</title>
-              <meta http-equiv="refresh" content="0; url=https://github.com/${{ github.repository }}/releases/download/schemas-$HIGHEST_VERSION/schemas-$HIGHEST_VERSION.zip">
-            </head>
-            <body>
-              <h1>CrackingShells Schemas</h1>
-              <p>Redirecting to latest version ($HIGHEST_VERSION)...</p>
-              <p><a href="https://github.com/${{ github.repository }}/releases/download/schemas-$HIGHEST_VERSION/schemas-$HIGHEST_VERSION.zip">Click here if you are not redirected automatically</a></p>
-            </body>
-          </html>
-          EOF
-          
-          # Create a JSON file with version information for API consumers
-          cat > gh-pages-content/latest.json << EOF
-          {
-            "latest_version": "$HIGHEST_VERSION",
-            "release_url": "https://github.com/${{ github.repository }}/releases/tag/schemas-$HIGHEST_VERSION",
-            "download_url": "https://github.com/${{ github.repository }}/releases/download/schemas-$HIGHEST_VERSION/schemas-$HIGHEST_VERSION.zip",
-            "schema_urls": {
-              "package": "https://raw.githubusercontent.com/${{ github.repository }}/main/package/$HIGHEST_VERSION/hatch_pkg_metadata_schema.json",
-              "registry": "https://raw.githubusercontent.com/${{ github.repository }}/main/registry/$HIGHEST_VERSION/hatch_all_pkg_metadata_schema.json"
-            },
-            "updated_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          }
-          EOF
+          # Generate the GitHub Pages content with our script
+          echo "Generating GitHub Pages content..."
+          ./scripts/generate_gh_pages.sh ./gh-pages-content "$HIGHEST_PKG_VERSION" "$HIGHEST_REGISTRY_VERSION" "${{ github.repository }}"
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3
@@ -228,20 +180,29 @@ jobs:
           echo ""
           echo "URLs for each version:"
           
-          # Get the versions as an array
-          VERSIONS_ARRAY=$(echo $VERSIONS | jq -r '.[]')
+          # Get the package versions as an array
+          PKG_VERSIONS_ARRAY=$(echo $PKG_VERSIONS | jq -r '.[]')
           
-          # Report URLs for each version
-          for VERSION in $VERSIONS_ARRAY; do
-            echo "Version $VERSION:"
-            echo "- Download: https://github.com/${{ github.repository }}/releases/download/schemas-$VERSION/schemas-$VERSION.zip"
+          # Report URLs for each package version
+          for VERSION in $PKG_VERSIONS_ARRAY; do
+            echo "Package Version $VERSION:"
+            echo "- Download: https://github.com/${{ github.repository }}/releases/download/schemas-package-$VERSION/schemas-package-$VERSION.zip"
+          done
+          
+          # Get the registry versions as an array
+          REGISTRY_VERSIONS_ARRAY=$(echo $REGISTRY_VERSIONS | jq -r '.[]')
+          
+          # Report URLs for each registry version
+          for VERSION in $REGISTRY_VERSIONS_ARRAY; do
+            echo "Registry Version $VERSION:"
+            echo "- Download: https://github.com/${{ github.repository }}/releases/download/schemas-registry-$VERSION/schemas-registry-$VERSION.zip"
           done
           
           echo ""
-          echo "Latest version pointer:"
+          echo "Latest version pointers:"
           echo "- Web: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
           echo "- API: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/latest.json"
           echo ""
           echo "Direct schema URLs (always current):"
-          echo "- Package: https://raw.githubusercontent.com/${{ github.repository }}/main/package/$HIGHEST_VERSION/hatch_pkg_metadata_schema.json"
-          echo "- Registry: https://raw.githubusercontent.com/${{ github.repository }}/main/registry/$HIGHEST_VERSION/hatch_all_pkg_metadata_schema.json"
+          echo "- Package: https://raw.githubusercontent.com/${{ github.repository }}/main/package/$HIGHEST_PKG_VERSION/hatch_pkg_metadata_schema.json"
+          echo "- Registry: https://raw.githubusercontent.com/${{ github.repository }}/main/registry/$HIGHEST_REGISTRY_VERSION/hatch_all_pkg_metadata_schema.json"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,139 @@
 # Hatch-Schemas
-The various schemas used in various repositories on Hatch!
+
+JSON schemas for the CrackingShells organization package ecosystem.
+
+## Available Schemas
+
+This repository contains JSON schemas for validating Hatch metadata:
+
+- **Package Schema**: Validates individual package metadata
+  - Latest: `package/v1/hatch_pkg_metadata_schema.json`
+  - Versioned: `package/v1/hatch_pkg_metadata_schema.json`
+
+- **Registry Schema**: Validates the central package registry
+  - Latest: `registry/v1/hatch_all_pkg_metadata_schema.json`
+  - Versioned: `registry/v1/hatch_all_pkg_metadata_schema.json`
+
+## Schema Details
+
+### Package Schema
+
+The Package Schema (`hatch_pkg_metadata_schema.json`) defines the structure for individual package metadata files and includes:
+
+- Basic package identification (name, version, description)
+- Author and contributor information
+- Package dependencies (both Hatch packages and Python dependencies)
+- Compatibility requirements
+- Entry points and tools
+- Citation information
+
+### Registry Schema
+
+The Registry Schema (`hatch_all_pkg_metadata_schema.json`) defines the structure for the central package registry and includes:
+
+- Repository listings
+- Package versioning and dependency tracking
+- Artifact references and verification data
+- Repository-wide statistics
+- Change tracking between versions
+
+## Using These Schemas
+
+### Distribution Method
+
+These schemas are distributed through:
+
+1. **GitHub Releases** - Each version is packaged as a zip file attached to a release
+2. **GitHub Pages** - Provides a "latest" pointer that redirects to the most recent version
+3. **Raw GitHub Content** - Direct access to schema files in the repository
+
+### URL Format
+
+```
+# For the latest version info (JSON format):
+https://crackingshells.github.io/Hatch-Schemas/latest.json
+
+# For direct download of the latest schema package:
+https://crackingshells.github.io/Hatch-Schemas/ (redirects to latest release)
+
+# For a specific version package:
+https://github.com/crackingshells/Hatch-Schemas/releases/download/schemas-package-v1/schemas-package-v1.zip
+https://github.com/crackingshells/Hatch-Schemas/releases/download/schemas-registry-v1/schemas-registry-v1.zip
+
+# For direct access to schema files:
+https://raw.githubusercontent.com/crackingshells/Hatch-Schemas/main/package/v1/hatch_pkg_metadata_schema.json
+https://raw.githubusercontent.com/crackingshells/Hatch-Schemas/main/registry/v1/hatch_all_pkg_metadata_schema.json
+```
+
+### Referencing in Your JSON Files
+
+You can reference these schemas in your JSON files using the `$schema` property:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/crackingshells/Hatch-Schemas/main/package/v1/hatch_pkg_metadata_schema.json",
+  "name": "my_package",
+  "version": "1.0.0",
+  ...
+}
+```
+
+### Programmatic Usage
+
+#### Basic Validation
+
+To validate against these schemas programmatically:
+
+```python
+import requests
+import jsonschema
+
+# Fetch the schema
+schema_url = "https://raw.githubusercontent.com/crackingshells/Hatch-Schemas/main/package/v1/hatch_pkg_metadata_schema.json"
+schema = requests.get(schema_url).json()
+
+# Your package data
+package_data = {
+    "name": "my_package",
+    "version": "1.0.0",
+    # ...other required fields
+}
+
+# Validate
+jsonschema.validate(package_data, schema)
+```
+
+#### Automatic Schema Updates
+
+We provide a helper utility (`schema_updater.py` in the examples directory) that manages schema caching and updates:
+
+```python
+from examples.schema_updater import load_schema, configure_logger
+import logging
+
+# Optional: Configure logging
+configure_logger(level=logging.INFO)
+
+# Load the latest schema (automatically downloads if needed)
+package_schema = load_schema("package")
+registry_schema = load_schema("registry")
+
+# Use the schemas
+import jsonschema
+jsonschema.validate(my_package_data, package_schema)
+```
+
+## Schema Versioning
+
+New schema versions are published automatically when changes to versioned schema folders (e.g., `package/v1/`, `registry/v1/`) are merged to `main`. The workflow:
+
+1. Detects which versions were modified
+2. Creates GitHub Releases for each modified version
+3. Updates the "latest" pointer to the highest version number
+4. Generates a `latest.json` file with metadata about the release
+
+The `latest` alias always points to the most recently published schema version.
+
+## License
+
+See the [LICENSE](LICENSE) file for details.

--- a/examples/schema_updater.py
+++ b/examples/schema_updater.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python
+"""
+Schema Update Checker Example
+
+This script demonstrates how to:
+1. Check for the latest schema version for each schema type
+2. Compare with a locally cached version
+3. Download the latest schema if needed
+"""
+
+import os
+import json
+import shutil
+import logging
+import requests
+from pathlib import Path
+from datetime import datetime
+import tempfile
+import zipfile
+
+# Configure logging
+logger = logging.getLogger("schema_updater")
+logger.setLevel(logging.INFO)
+
+# Configuration
+SCHEMA_INFO_URL = "https://crackingshells.github.io/Hatch-Schemas/latest.json"
+CACHE_DIR = Path.home() / ".crackingshells" / "schemas"
+CACHE_INFO_FILE = CACHE_DIR / "schema_info.json"
+
+
+def configure_logger(level=logging.INFO, log_file=None):
+    """Configure the logger with custom settings.
+    
+    Args:
+        level: The logging level (e.g., logging.DEBUG, logging.INFO)
+        log_file: Optional path to a log file
+    """
+    logger.setLevel(level)
+    
+    # Remove existing handlers
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+    
+    # Add console handler
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+    logger.addHandler(console_handler)
+    
+    # Add file handler if specified
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        logger.addHandler(file_handler)
+
+
+def get_latest_schema_info():
+    """Fetch information about the latest schema versions."""
+    try:
+        logger.debug(f"Requesting schema info from {SCHEMA_INFO_URL}")
+        response = requests.get(SCHEMA_INFO_URL, timeout=10)
+        response.raise_for_status()
+        logger.debug("Schema info retrieved successfully")
+        return response.json()
+    except requests.RequestException as e:
+        logger.error(f"Error fetching schema info: {e}")
+        return None
+
+
+def get_cached_schema_info():
+    """Get information about the locally cached schema versions."""
+    if not CACHE_INFO_FILE.exists():
+        logger.debug("No cached schema info found")
+        return None
+    
+    try:
+        logger.debug(f"Reading cached schema info from {CACHE_INFO_FILE}")
+        with open(CACHE_INFO_FILE, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        logger.error(f"Error reading cached schema info: {e}")
+        return None
+
+
+def download_and_extract_schema(schema_type, download_url):
+    """Download and extract schema files to the cache directory for a specific schema type.
+    
+    Args:
+        schema_type: Either "package" or "registry"
+        download_url: URL to download the schema ZIP archive
+    """
+    try:
+        # Create a temporary file to download to
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".zip") as temp_file:
+            temp_path = temp_file.name
+        
+        # Download the schema zip
+        logger.info(f"Downloading {schema_type} schema from {download_url}")
+        response = requests.get(download_url, stream=True, timeout=30)
+        response.raise_for_status()
+        
+        # Save to temporary file
+        with open(temp_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+        
+        # Clear existing cache directory for this schema type
+        schema_cache_dir = CACHE_DIR / schema_type
+        if schema_cache_dir.exists():
+            logger.debug(f"Clearing existing cache directory: {schema_cache_dir}")
+            shutil.rmtree(schema_cache_dir)
+        
+        # Create schema type directory
+        schema_cache_dir.mkdir(parents=True, exist_ok=True)
+        
+        with zipfile.ZipFile(temp_path, 'r') as zip_ref:
+            logger.debug(f"Extracting {schema_type} schema to {schema_cache_dir}")
+            zip_ref.extractall(schema_cache_dir)
+            
+            # Find the version directory in the extracted content
+            extracted_dirs = [d for d in os.listdir(schema_cache_dir) if os.path.isdir(os.path.join(schema_cache_dir, d))]
+            if extracted_dirs:
+                version_dir = extracted_dirs[0]
+                extracted_version_path = os.path.join(schema_cache_dir, version_dir)
+                
+                logger.debug(f"Restructuring extracted content from {version_dir} directory")
+                # Move the contents up one level (from cache_dir/package/v1/... to cache_dir/package/...)
+                for item in os.listdir(extracted_version_path):
+                    target_path = os.path.join(schema_cache_dir, item)
+                    source_path = os.path.join(extracted_version_path, item)
+                    
+                    # Remove existing file/directory if it exists
+                    if os.path.exists(target_path):
+                        if os.path.isdir(target_path):
+                            shutil.rmtree(target_path)
+                        else:
+                            os.remove(target_path)
+                    
+                    # Move the item
+                    shutil.move(source_path, target_path)
+                
+                # Remove the now-empty version directory
+                if os.path.exists(extracted_version_path):
+                    shutil.rmtree(extracted_version_path)
+        
+        # Clean up the temporary file
+        os.unlink(temp_path)
+        logger.debug(f"{schema_type.capitalize()} schema extraction completed successfully")
+        
+        return True
+    except Exception as e:
+        logger.error(f"Error downloading {schema_type} schema: {e}", exc_info=True)
+        return False
+
+
+def update_cache_info(schema_info):
+    """Update the cached schema information."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    
+    try:
+        logger.debug(f"Writing updated schema info to {CACHE_INFO_FILE}")
+        with open(CACHE_INFO_FILE, "w") as f:
+            json.dump(schema_info, f, indent=2)
+        return True
+    except IOError as e:
+        logger.error(f"Error writing cache info: {e}")
+        return False
+
+
+def check_and_update_schemas():
+    """Check if new schema versions are available and update if needed."""
+    # Get info about the latest available schemas
+    latest_info = get_latest_schema_info()
+    if not latest_info:
+        logger.warning("Could not retrieve latest schema information. Using cached version if available.")
+        return False
+    
+    # Get info about the cached schemas
+    cached_info = get_cached_schema_info()
+    
+    updated = False
+    
+    # Check and update each schema type separately
+    for schema_type in ["package", "registry"]:
+        # Skip if this schema type is not in the latest info
+        if schema_type not in latest_info:
+            logger.debug(f"No {schema_type} schema information in the latest info")
+            continue
+            
+        latest_version_key = f"latest_{schema_type}_version"
+        latest_version = latest_info.get(latest_version_key)
+        
+        # Skip if no latest version is defined
+        if not latest_version:
+            logger.debug(f"No latest version for {schema_type} schema")
+            continue
+        
+        needs_update = True
+        
+        # Check if we have this version cached already
+        if cached_info and schema_type in cached_info:
+            cached_version_key = f"latest_{schema_type}_version"
+            cached_version = cached_info.get(cached_version_key)
+            
+            if cached_version == latest_version:
+                # Check if the cached version is up to date
+                cached_updated = datetime.fromisoformat(cached_info.get("updated_at", "1970-01-01T00:00:00Z").replace("Z", "+00:00"))
+                latest_updated = datetime.fromisoformat(latest_info.get("updated_at", "1970-01-01T00:00:00Z").replace("Z", "+00:00"))
+                
+                if cached_updated >= latest_updated:
+                    logger.info(f"{schema_type.capitalize()} schema is up to date (version {latest_version}).")
+                    needs_update = False
+        
+        # Update schema if needed
+        if needs_update:
+            download_url = latest_info.get(schema_type, {}).get("download_url")
+            if download_url:
+                logger.info(f"New {schema_type} schema version available: {latest_version}")
+                if download_and_extract_schema(schema_type, download_url):
+                    updated = True
+                    logger.info(f"{schema_type.capitalize()} schema updated successfully.")
+                else:
+                    logger.error(f"{schema_type.capitalize()} schema update failed.")
+            else:
+                logger.warning(f"No download URL found for {schema_type} schema")
+    
+    # Update cache info after all schemas are updated
+    if updated:
+        update_cache_info(latest_info)
+    
+    return updated
+
+
+def load_schema(schema_type="package"):
+    """Load a schema from the cache.
+    
+    Args:
+        schema_type: Either "package" or "registry"
+        
+    Returns:
+        The schema as a dictionary, or None if not available
+    """
+    # Ensure schemas are up to date
+    check_and_update_schemas()
+    
+    # Get the cached schema info to determine current version
+    cached_info = get_cached_schema_info()
+    if not cached_info:
+        logger.warning("No cached schema information available.")
+        return None
+    
+    # Get the specific schema info
+    schema_info = cached_info.get(schema_type, {})
+    if not schema_info:
+        logger.warning(f"No {schema_type} schema information available in the cache.")
+        return None
+    
+    # Get the schema version
+    version = schema_info.get("version")
+    if not version:
+        version_key = f"latest_{schema_type}_version"
+        version = cached_info.get(version_key)
+        if not version:
+            logger.error(f"No version information for {schema_type} schema in cached schema info")
+            return None
+    
+    # Ensure version has 'v' prefix
+    if not version.startswith('v'):
+        version = f"v{version}"
+    
+    # Determine schema filename based on type
+    if schema_type == "package":
+        schema_filename = "hatch_pkg_metadata_schema.json"
+    elif schema_type == "registry":
+        schema_filename = "hatch_all_pkg_metadata_schema.json"
+    else:
+        logger.error(f"Unknown schema type: {schema_type}")
+        raise ValueError(f"Unknown schema type: {schema_type}")
+    
+    # Load and return the schema
+    schema_path = CACHE_DIR / schema_type / schema_filename
+    if schema_path.exists():
+        try:
+            logger.debug(f"Loading {schema_type} schema from {schema_path}")
+            with open(schema_path, "r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError) as e:
+            logger.error(f"Error loading {schema_type} schema: {e}")
+            return None
+    else:
+        logger.warning(f"{schema_type.capitalize()} schema file not found: {schema_path}")
+        return None
+
+
+if __name__ == "__main__":
+    # Set up logging
+    configure_logger(
+        level=logging.INFO,
+        log_file=str(Path.home() / ".crackingshells" / "logs" / "schema_updates.log")
+    )
+    
+    # Example usage
+    updated = check_and_update_schemas()
+    
+    if updated:
+        logger.info("Downloaded new schemas")
+    
+    # Load and use the schemas
+    package_schema = load_schema("package")
+    registry_schema = load_schema("registry")
+    
+    if package_schema:
+        logger.info(f"Package schema title: {package_schema.get('title')}")
+    
+    if registry_schema:
+        logger.info(f"Registry schema title: {registry_schema.get('title')}")

--- a/scripts/create_releases.sh
+++ b/scripts/create_releases.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# create_releases.sh
+#
+# This script creates GitHub releases for both package and registry schemas
+#
+# Usage: ./create_releases.sh [artifacts_dir] [pkg_versions_json] [registry_versions_json]
+#
+# Environment variables required:
+# - GITHUB_TOKEN: GitHub token for authentication
+
+set -eo pipefail
+
+# Get arguments
+ARTIFACTS_DIR="${1:-./artifacts}"
+PKG_VERSIONS_JSON="${2:-[]}"
+REGISTRY_VERSIONS_JSON="${3:-[]}"
+
+# Define schema types and their configurations
+declare -A VERSIONS_JSON=(
+  ["package"]="$PKG_VERSIONS_JSON"
+  ["registry"]="$REGISTRY_VERSIONS_JSON"
+)
+
+# Ensure GitHub CLI is installed
+if ! command -v gh &> /dev/null; then
+    echo "Error: GitHub CLI not found. Please install it first."
+    exit 1
+fi
+
+# Check if GITHUB_TOKEN is set
+if [[ -z "$GITHUB_TOKEN" ]]; then
+    echo "Warning: GITHUB_TOKEN environment variable not set."
+    echo "You may need to authenticate with GitHub CLI manually."
+fi
+
+# Create releases for a specific schema type
+create_releases() {
+    local schema_type=$1
+    local versions_json=${VERSIONS_JSON[$schema_type]}
+    
+    # Convert JSON array to bash array
+    local versions
+    versions=$(echo "$versions_json" | jq -r '.[]')
+    
+    for VERSION in $versions; do
+        echo "Creating release for ${schema_type} version: $VERSION"
+        
+        # Get release asset path
+        ASSET_PATH="$ARTIFACTS_DIR/${schema_type}/schemas-${schema_type}-$VERSION.zip"
+        
+        if [[ ! -f "$ASSET_PATH" ]]; then
+            echo "Warning: Asset file not found at $ASSET_PATH"
+            continue
+        fi
+        
+        # Create release notes
+        RELEASE_NOTES="${schema_type^} schema version $VERSION released on $(date -u +"%Y-%m-%d")"
+        
+        # Create a GitHub release using GitHub CLI
+        gh release create "schemas-${schema_type}-$VERSION" \
+            --title "${schema_type^} Schema Release $VERSION" \
+            --notes "$RELEASE_NOTES" \
+            "$ASSET_PATH" || echo "Failed to create release for ${schema_type} version $VERSION"
+            
+        echo "Release created for ${schema_type} version $VERSION"
+    done
+}
+
+# Process each schema type
+for schema_type in "${!VERSIONS_JSON[@]}"; do
+    if [[ "${VERSIONS_JSON[$schema_type]}" != "[]" ]]; then
+        create_releases "$schema_type"
+        echo "All ${schema_type} releases created successfully"
+    else
+        echo "No ${schema_type} releases to create"
+    fi
+done
+
+echo "Release creation complete"

--- a/scripts/detect_versions.sh
+++ b/scripts/detect_versions.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# detect_versions.sh
+#
+# This script detects schema versions from a list of changed files
+# It outputs version information for package and registry schemas separately
+#
+# Usage: ./detect_versions.sh [file1] [file2] ... [fileN]
+#   Or pipe in file list: cat file_list.txt | ./detect_versions.sh
+
+# Define schema types to process
+SCHEMA_TYPES=("package" "registry")
+
+# Initialize associative arrays for tracking versions
+declare -A VERSIONS_ARRAY
+declare -A HIGHEST_VERSION
+declare -A VERSIONS_JSON
+
+# Process files either from arguments or stdin
+FILES=("$@")
+if [ $# -eq 0 ]; then
+  while read -r line; do
+    FILES+=("$line")
+  done
+fi
+
+echo "Processing ${#FILES[@]} changed files"
+
+# Function to extract version from file path
+extract_version() {
+  local file=$1
+  local schema_type=$2
+  echo "$file" | grep -o "${schema_type}/v[0-9]\+\(\.[0-9]\+\)*" | cut -d'/' -f2
+}
+
+# Extract directory versions from changed files
+for file in "${FILES[@]}"; do
+  # Process each schema type
+  for schema_type in "${SCHEMA_TYPES[@]}"; do
+    if [[ $file == ${schema_type}/v* ]]; then
+      VERSION=$(extract_version "$file" "$schema_type")
+      if [[ ! -z "$VERSION" ]]; then
+        VERSIONS_ARRAY[${schema_type}]+=" $VERSION"
+        echo "Found ${schema_type} schema version: $VERSION"
+      fi
+    fi
+  done
+done
+
+# Process each schema type to get unique versions and determine highest version
+for schema_type in "${SCHEMA_TYPES[@]}"; do
+  # Get unique versions
+  if [[ ! -z "${VERSIONS_ARRAY[${schema_type}]}" ]]; then
+    UNIQUE_VERSIONS=($(echo "${VERSIONS_ARRAY[${schema_type}]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+    echo "${schema_type^} schema versions: ${UNIQUE_VERSIONS[*]}"
+    
+    # Find highest version
+    HIGHEST_VERSION[${schema_type}]=$(echo "${UNIQUE_VERSIONS[*]}" | tr ' ' '\n' | sort -Vr | head -n1)
+    # Create JSON array
+    VERSIONS_JSON[${schema_type}]="[\"$(echo "${UNIQUE_VERSIONS[@]}" | sed 's/ /\", \"/g')\"]"
+  else
+    # No schema changes detected for this type
+    HIGHEST_VERSION[${schema_type}]=""
+    VERSIONS_JSON[${schema_type}]="[]"
+  fi
+done
+
+# Output results in GitHub Actions compatible format (legacy format)
+echo "::set-output name=pkg_versions::${VERSIONS_JSON[package]}"
+echo "::set-output name=registry_versions::${VERSIONS_JSON[registry]}"
+echo "::set-output name=highest_pkg_version::${HIGHEST_VERSION[package]}"
+echo "::set-output name=highest_registry_version::${HIGHEST_VERSION[registry]}"
+
+# Also output in the modern GitHub Actions compatible format
+{
+  echo "pkg_versions=${VERSIONS_JSON[package]}" >> "$GITHUB_OUTPUT" 
+  echo "registry_versions=${VERSIONS_JSON[registry]}" >> "$GITHUB_OUTPUT"
+  echo "highest_pkg_version=${HIGHEST_VERSION[package]}" >> "$GITHUB_OUTPUT"
+  echo "highest_registry_version=${HIGHEST_VERSION[registry]}" >> "$GITHUB_OUTPUT"
+} 2>/dev/null || true  # Ignore errors if GITHUB_OUTPUT isn't set

--- a/scripts/generate_gh_pages.sh
+++ b/scripts/generate_gh_pages.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# generate_gh_pages.sh
+#
+# This script generates GitHub Pages content with latest schema information
+#
+# Usage: ./generate_gh_pages.sh [output_dir] [highest_pkg_version] [highest_registry_version] [repo]
+#
+# Example:
+# ./generate_gh_pages.sh ./gh-pages-content v1 v1 "username/repo-name"
+
+set -eo pipefail
+
+# Get arguments
+OUTPUT_DIR="${1:-./gh-pages-content}"
+HIGHEST_PKG_VERSION="${2}"
+HIGHEST_REGISTRY_VERSION="${3}"
+REPO="${4:-$GITHUB_REPOSITORY}"
+
+# Define schema types and their configurations
+declare -A SCHEMA_CONFIGS=(
+  ["package"]="hatch_pkg_metadata_schema.json"
+  ["registry"]="hatch_all_pkg_metadata_schema.json"
+)
+
+declare -A HIGHEST_VERSIONS=(
+  ["package"]="$HIGHEST_PKG_VERSION"
+  ["registry"]="$HIGHEST_REGISTRY_VERSION"
+)
+
+echo "Generating GitHub Pages content in $OUTPUT_DIR"
+echo "Highest package version: $HIGHEST_PKG_VERSION"
+echo "Highest registry version: $HIGHEST_REGISTRY_VERSION"
+echo "Repository: $REPO"
+
+# Create output directory if it doesn't exist
+mkdir -p "$OUTPUT_DIR"
+
+# Function to generate HTML schema links section
+generate_schema_section() {
+  local schema_type=$1
+  local version=${HIGHEST_VERSIONS[$schema_type]}
+  local file_name=${SCHEMA_CONFIGS[$schema_type]}
+  
+  if [[ -z "$version" ]]; then
+    return
+  fi
+  
+  cat << EOS
+        <h2>${schema_type^} Schemas</h2>
+        <div class="schema-link">
+          <strong>Latest version:</strong> ${version}
+          <br>
+          <a href="https://github.com/$REPO/releases/tag/schemas-${schema_type}-${version}">Release page</a> |
+          <a href="https://github.com/$REPO/releases/download/schemas-${schema_type}-${version}/schemas-${schema_type}-${version}.zip">Download ZIP</a> |
+          <a href="https://raw.githubusercontent.com/$REPO/main/${schema_type}/${version}/${file_name}">View JSON</a>
+        </div>
+EOS
+}
+
+# Create index.html file
+cat > "$OUTPUT_DIR/index.html" << EOF
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Hatch Schemas</title>
+    <meta http-equiv="refresh" content="0; url=https://github.com/$REPO/releases">
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        line-height: 1.6;
+        color: #24292e;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { color: #2188ff; }
+      a { color: #0366d6; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .container { margin-top: 40px; }
+      .schema-link { margin-bottom: 10px; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Hatch Schemas</h1>
+      <p>This page provides access to the latest schema versions:</p>
+      
+      <div class="schema-versions">
+$(generate_schema_section "package")
+        
+$(generate_schema_section "registry")
+      </div>
+      
+      <p>You are being redirected to the releases page...</p>
+    </div>
+  </body>
+</html>
+EOF
+
+# Function to generate JSON object for a schema type
+generate_json_section() {
+  local schema_type=$1
+  local version=${HIGHEST_VERSIONS[$schema_type]}
+  local file_name=${SCHEMA_CONFIGS[$schema_type]}
+  
+  if [[ -z "$version" ]]; then
+    return
+  fi
+  
+  cat << EOS
+  "${schema_type}": {
+    "version": "${version}",
+    "release_url": "https://github.com/${REPO}/releases/tag/schemas-${schema_type}-${version}",
+    "download_url": "https://github.com/${REPO}/releases/download/schemas-${schema_type}-${version}/schemas-${schema_type}-${version}.zip",
+    "schema_url": "https://raw.githubusercontent.com/${REPO}/main/${schema_type}/${version}/${file_name}"
+  }
+EOS
+}
+
+# Create latest.json file with version information
+cat > "$OUTPUT_DIR/latest.json" << EOF
+{
+  "latest_package_version": "${HIGHEST_PKG_VERSION}",
+  "latest_registry_version": "${HIGHEST_REGISTRY_VERSION}",
+$(generate_json_section "package"),
+$(generate_json_section "registry"),
+  "updated_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+}
+EOF
+
+echo "GitHub Pages content generated successfully in $OUTPUT_DIR"

--- a/scripts/package_schemas.sh
+++ b/scripts/package_schemas.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# package_schemas.sh
+#
+# This script packages schema files for release, creating separate artifacts for
+# both package and registry schemas
+#
+# Usage: ./package_schemas.sh [artifacts_dir] [pkg_versions_json] [registry_versions_json] [commit_sha]
+#
+# Example:
+# ./package_schemas.sh ./artifacts '["v1","v2"]' '["v1"]' "abc123"
+
+set -eo pipefail
+
+# Get arguments
+ARTIFACTS_DIR="${1:-./artifacts}"
+PKG_VERSIONS_JSON="${2:-[]}"
+REGISTRY_VERSIONS_JSON="${3:-[]}"
+COMMIT_SHA="${4:-$(git rev-parse HEAD)}"
+
+# Define schema types and their configurations
+declare -A VERSIONS_JSON=(
+  ["package"]="$PKG_VERSIONS_JSON"
+  ["registry"]="$REGISTRY_VERSIONS_JSON"
+)
+
+# Create artifacts directory if it doesn't exist
+mkdir -p "$ARTIFACTS_DIR"
+
+echo "Packaging schemas to $ARTIFACTS_DIR"
+echo "Package versions: $PKG_VERSIONS_JSON"
+echo "Registry versions: $REGISTRY_VERSIONS_JSON"
+
+# Process versions for a specific schema type
+process_versions() {
+    local schema_type=$1
+    local versions_json=${VERSIONS_JSON[$schema_type]}
+    
+    # Convert JSON array to bash array
+    local versions
+    versions=$(echo "$versions_json" | jq -r '.[]')
+    
+    for VERSION in $versions; do
+        echo "Processing ${schema_type} version: $VERSION"
+        mkdir -p "$ARTIFACTS_DIR/${schema_type}/$VERSION"
+        
+        # Copy schemas to versioned directory
+        cp -r "${schema_type}/$VERSION" "$ARTIFACTS_DIR/${schema_type}/"
+        
+        # Create metadata files for each version
+        echo "{
+            \"version\": \"$VERSION\",
+            \"build_date\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\",
+            \"commit\": \"$COMMIT_SHA\"
+        }" > "$ARTIFACTS_DIR/${schema_type}/$VERSION/metadata.json"
+        
+        # Create version-specific zip for release
+        echo "Creating zip archive for ${schema_type} version $VERSION"
+        (cd "$ARTIFACTS_DIR/${schema_type}" && zip -r "schemas-${schema_type}-$VERSION.zip" "$VERSION")
+        
+        echo "${schema_type^} version $VERSION processed successfully"
+    done
+}
+
+# Process each schema type
+for schema_type in "${!VERSIONS_JSON[@]}"; do
+    if [[ "${VERSIONS_JSON[$schema_type]}" != "[]" ]]; then
+        process_versions "$schema_type"
+        echo "All ${schema_type} versions processed successfully"
+    else
+        echo "No ${schema_type} versions to process"
+    fi
+done
+
+echo "Schema packaging complete. Artifacts are available in $ARTIFACTS_DIR"

--- a/scripts/validate_schemas.sh
+++ b/scripts/validate_schemas.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# validate_schemas.sh
+#
+# This script validates the schema files for both package and registry schemas
+#
+# Usage: ./validate_schemas.sh [pkg_version] [registry_version]
+#   Where pkg_version and registry_version are optional
+#   If not provided, the script will try to find them
+
+# Set up environment
+set -eo pipefail
+
+# Define schema types and their configurations
+declare -A SCHEMA_CONFIGS=(
+  ["package"]="hatch_pkg_metadata_schema.json"
+  ["registry"]="hatch_all_pkg_metadata_schema.json"
+)
+
+# Get versions from arguments or environment variables
+VERSION_ARGS=("$@")
+PKG_VERSION="${VERSION_ARGS[0]:-$HIGHEST_PKG_VERSION}"
+REGISTRY_VERSION="${VERSION_ARGS[1]:-$HIGHEST_REGISTRY_VERSION}"
+
+# Store versions in associative array for easier iteration
+declare -A VERSIONS=(
+  ["package"]="$PKG_VERSION"
+  ["registry"]="$REGISTRY_VERSION"
+)
+
+# Check if ajv is available, install if needed
+if ! command -v ajv &> /dev/null; then
+    echo "AJV not found, installing..."
+    npm install -g ajv-cli ajv-formats
+fi
+
+VALID=true
+
+# Function to validate a schema
+validate_schema() {
+    local schema_type=$1
+    local version=$2
+    local file_name=${SCHEMA_CONFIGS[$schema_type]}
+    
+    echo "Validating ${schema_type} schema version: $version"
+    local schema_path="${schema_type}/${version}/${file_name}"
+    
+    if [[ -f "$schema_path" ]]; then
+        echo "${schema_type^} schema file found: $schema_path"
+        if ajv compile -s "$schema_path" --spec=draft7 -c ajv-formats; then
+            echo "✓ ${schema_type^} schema validation successful"
+            return 0
+        else
+            echo "✗ ${schema_type^} schema validation failed"
+            return 1
+        fi
+    else
+        echo "Warning: ${schema_type^} schema file not found at $schema_path"
+        return 0  # Not finding a file isn't a validation error
+    fi
+}
+
+# Validate each schema type
+for schema_type in "${!SCHEMA_CONFIGS[@]}"; do
+    version="${VERSIONS[$schema_type]}"
+    if [[ ! -z "$version" ]]; then
+        if ! validate_schema "$schema_type" "$version"; then
+            VALID=false
+        fi
+    else
+        echo "No ${schema_type} schema version provided for validation"
+    fi
+done
+
+# Final validation status
+if $VALID; then
+    echo "All schema validations passed"
+    exit 0
+else
+    echo "One or more schema validations failed"
+    exit 1
+fi


### PR DESCRIPTION
This pull request introduces the working deployment workflow to host the versions of the schemas. Also added documentation and example python script to retrieve the schemas.

### Workflow Enhancements

#### Modularization and Script Usage:
* Replaced inline schema validation, packaging, and GitHub Pages content generation logic with reusable scripts (`validate_schemas.sh`, `package_schemas.sh`, `generate_gh_pages.sh`, and `create_releases.sh`). This improves maintainability and reduces duplication across workflows. [[1]](diffhunk://#diff-9ada460b7d4bc9f8471862bac40468f7303b9bdabe7c500233aa7b3a3221733dL55-R62) [[2]](diffhunk://#diff-dbd6a336301809d47729ea2380d423938a842034a7839bae286f366f5e1f91ebL103-R149) [[3]](diffhunk://#diff-dbd6a336301809d47729ea2380d423938a842034a7839bae286f366f5e1f91ebL181-R166)

#### Manual Workflow Overrides:
* Introduced new `workflow_dispatch` inputs (`force`, `pkg_schema_version`, `registry_schema_version`) to allow manual triggering of deployments with specific versions, even when no changes are detected. [[1]](diffhunk://#diff-dbd6a336301809d47729ea2380d423938a842034a7839bae286f366f5e1f91ebL10-R33) [[2]](diffhunk://#diff-dbd6a336301809d47729ea2380d423938a842034a7839bae286f366f5e1f91ebL50-R89)