### PR TITLE
Update of shema deployment workflow

### DIFF
--- a/.github/workflows/schema-deployment.yml
+++ b/.github/workflows/schema-deployment.yml
@@ -8,12 +8,7 @@ on:
       - 'package/v*/**'
       - 'registry/v*/**'
       - '.github/workflows/schema-deployment.yml'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'package/v*/**'
-      - 'registry/v*/**'
+
   workflow_dispatch: # Allows manual triggering of the workflow
     inputs:
       force:

--- a/.github/workflows/schema-deployment.yml
+++ b/.github/workflows/schema-deployment.yml
@@ -50,7 +50,7 @@ jobs:
       registry_versions: ${{ steps.get-versions.outputs.registry_versions }}
       highest_pkg_version: ${{ steps.get-versions.outputs.highest_pkg_version }}
       highest_registry_version: ${{ steps.get-versions.outputs.highest_registry_version }}
-      changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
+      no-changes: ${{ steps.changed-files.outputs.all_changed_files == '' && github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force != 'true') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -64,6 +64,12 @@ jobs:
           files: |
             package/v*/**
             registry/v*/**
+
+      - name: Stop if no changes detected
+        if: steps.changed-files.outputs.all_changed_files == '' && github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force != 'true')
+        run: |
+          echo "No changes detected in package or registry schemas and force is not enabled. Exiting..."
+          exit 0
 
       - name: Detect versions from changed files
         id: get-versions
@@ -90,6 +96,7 @@ jobs:
           fi
 
   validate-schemas:
+    if: needs.detect-versions.outputs.no-changes == 'false'
     runs-on: ubuntu-latest
     needs: [detect-versions]
     steps:
@@ -114,6 +121,7 @@ jobs:
           ./scripts/validate_schemas.sh "${{ needs.detect-versions.outputs.highest_pkg_version }}" "${{ needs.detect-versions.outputs.highest_registry_version }}"
 
   build-deploy:
+    if: needs.detect-versions.outputs.no-changes == 'false'
     needs: [detect-versions, validate-schemas]
     runs-on: ubuntu-latest
     env:

--- a/scripts/detect_versions.sh
+++ b/scripts/detect_versions.sh
@@ -64,16 +64,8 @@ for schema_type in "${SCHEMA_TYPES[@]}"; do
   fi
 done
 
-# Output results in GitHub Actions compatible format (legacy format)
-echo "::set-output name=pkg_versions::${VERSIONS_JSON[package]}"
-echo "::set-output name=registry_versions::${VERSIONS_JSON[registry]}"
-echo "::set-output name=highest_pkg_version::${HIGHEST_VERSION[package]}"
-echo "::set-output name=highest_registry_version::${HIGHEST_VERSION[registry]}"
-
-# Also output in the modern GitHub Actions compatible format
-{
-  echo "pkg_versions=${VERSIONS_JSON[package]}" >> "$GITHUB_OUTPUT" 
-  echo "registry_versions=${VERSIONS_JSON[registry]}" >> "$GITHUB_OUTPUT"
-  echo "highest_pkg_version=${HIGHEST_VERSION[package]}" >> "$GITHUB_OUTPUT"
-  echo "highest_registry_version=${HIGHEST_VERSION[registry]}" >> "$GITHUB_OUTPUT"
-} 2>/dev/null || true  # Ignore errors if GITHUB_OUTPUT isn't set
+# Output in the GitHub Actions compatible format
+echo "pkg_versions=${VERSIONS_JSON[package]}" >> "$GITHUB_OUTPUT" 
+echo "registry_versions=${VERSIONS_JSON[registry]}" >> "$GITHUB_OUTPUT"
+echo "highest_pkg_version=${HIGHEST_VERSION[package]}" >> "$GITHUB_OUTPUT"
+echo "highest_registry_version=${HIGHEST_VERSION[registry]}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This pull request refines the schema deployment workflow. Key changes include removing unnecessary triggers, adding conditional checks to avoid unnecessary job executions, and updating the script to use the modern GitHub Actions output format.

### Workflow Improvements:
* Removed the `pull_request` trigger in `.github/workflows/schema-deployment.yml` to streamline the workflow and rely solely on manual (`workflow_dispatch`) or other `push` to branch `main`.
* Added a conditional step (`Stop if no changes detected`) to terminate the workflow early if no relevant changes are detected or if the force flag is not enabled during manual runs.
* Introduced conditional execution for `validate-schemas` and `build-deploy` jobs to skip them when no changes are detected, improving efficiency. [[1]](diffhunk://#diff-dbd6a336301809d47729ea2380d423938a842034a7839bae286f366f5e1f91ebR94) [[2]](diffhunk://#diff-dbd6a336301809d47729ea2380d423938a842034a7839bae286f366f5e1f91ebR119)

### Script Modernization:
* Updated `scripts/detect_versions.sh` to remove deprecated `::set-output` commands and exclusively use `$GITHUB_OUTPUT` format for outputting results. 