### PR TITLE
Schema Updates

### DIFF
--- a/package/v1.1.0/hatch_pkg_metadata_schema.json
+++ b/package/v1.1.0/hatch_pkg_metadata_schema.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Hatch Package Metadata",
+    "description": "Schema for Hatch MCP Server package metadata",
+    "type": "object",
+    "required": ["package_schema_version", "name", "version", "entry_point", "description", "category", "tags", "author", "license"],
+    "properties": {
+        "package_schema_version": {
+            "type": "string",
+            "description": "Version of the schema used for this package metadata",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "name": {
+            "type": "string",
+            "description": "Package identifier",
+            "pattern": "^[a-z0-9_]+$"
+        },
+        "version": {
+            "type": "string",
+            "description": "Semantic version of the package",
+            "pattern": "^\\d+(\\.\\d+)*$"
+        },
+        "description": {
+            "type": "string",
+            "description": "Human-readable description of the package"
+        },
+        "category": {
+            "type": "string",
+            "description": "Scientific domain or category"
+        },
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Keywords for discovery"
+        },
+        "author": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {"type": "string"},
+                "email": {"type": "string", "format": "email"}
+            }
+        },
+        "contributors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "email": {"type": "string", "format": "email"}
+                }
+            }
+        },
+        "license": {"type": "string"},
+        "repository": {"type": "string", "format": "uri"},
+        "documentation": {"type": "string", "format": "uri"},
+        "hatch_dependencies": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name", "type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["local", "remote"],
+                        "description": "Type of dependency"
+                    },
+                    "uri": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "URI for the dependency. If local, expecting a path to a local directory. If remote, expecting a URL. Local exists for package development but is not allowed in the registry."
+                    },
+                    "name": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9_]+$",
+                        "description": "Name of the dependent package"
+                    },
+                    "version_constraint": {
+                        "type": "string",
+                        "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                        "description": "Version constraint (e.g., '>=1.0.0', '==1.2.3')"
+                    }
+                }
+            },
+            "description": "Other Hatch packages required."
+        },
+        "python_dependencies": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]+$",
+                        "description": "Name of the Python package"
+                    },
+                    "version_constraint": {
+                        "type": "string",
+                        "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                        "description": "Version constraint (e.g., '>=1.0.0', '==1.2.3')"
+                    },
+                    "package_manager": {
+                        "type": "string",
+                        "enum": ["pip", "conda"],
+                        "default": "pip",
+                        "description": "Package manager to use for installation"
+                    }
+                }
+            },
+            "description": "Python packages required."
+        },
+        "compatibility": {
+            "type": "object",
+            "properties": {
+                "hatchling": {
+                    "type": "string",
+                    "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                    "description": "Version constraint for Hatchling compatibility, e.g., '>=0.1.0'"
+                },
+                "python": {
+                    "type": "string",
+                    "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                    "description": "Version constraint for Python compatibility, e.g., '>=3.6'"
+                }
+            }
+        },
+        "entry_point": {"type": "string"},
+        "tools": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name", "description"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "description": {"type": "string"}
+                }
+            }
+        },
+        "citations": {
+            "type": "object",
+            "properties": {
+                "origin": {"type": "string"},
+                "mcp": {"type": "string"}
+            }
+        }
+    },
+    "additionalProperties": false
+}

--- a/registry/v1.1.0/hatch_all_pkg_metadata_schema.json
+++ b/registry/v1.1.0/hatch_all_pkg_metadata_schema.json
@@ -15,11 +15,6 @@
             "format": "date-time",
             "description": "Timestamp of when the registry was last updated"
         },
-        "artifact_base_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "Base URL for all CI/CD artifacts"
-        },
         "repositories": {
             "type": "array",
             "description": "List of repositories containing packages",
@@ -66,8 +61,17 @@
                                     "description": "Available versions of this package",
                                     "items": {
                                         "type": "object",
-                                        "required": ["version", "release_uri", "added_date"],
+                                        "required": ["author","version", "release_uri", "added_date"],
                                         "properties": {
+                                            "author": {
+                                                "type": "object",
+                                                "required": ["GitHubID", "email"],
+                                                "properties": {
+                                                    "GitHubID": {"type": "string"},
+                                                    "email": {"type": "string", "format": "email"}
+                                                },
+                                                "description": "Author of the submission of this version"
+                                            },
                                             "version": {
                                                 "type": "string",
                                                 "description": "Semantic version of the package",

--- a/registry/v1.1.0/hatch_all_pkg_metadata_schema.json
+++ b/registry/v1.1.0/hatch_all_pkg_metadata_schema.json
@@ -1,0 +1,254 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "CrackingShells Package Registry",
+    "description": "Schema for a centralized registry of all packages across CrackingShells repositories",
+    "type": "object",
+    "required": ["registry_schema_version", "last_updated", "repositories"],
+    "properties": {
+        "registry_schema_version": {
+            "type": "string",
+            "description": "Version of this registry schema",
+            "pattern": "^\\d+(\\.\\d+)*$"
+        },
+        "last_updated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when the registry was last updated"
+        },
+        "artifact_base_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Base URL for all CI/CD artifacts"
+        },
+        "repositories": {
+            "type": "array",
+            "description": "List of repositories containing packages",
+            "items": {
+                "type": "object",
+                "required": ["name", "url", "packages", "last_indexed"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Repository name (e.g., 'Hatch-Dev')"
+                    },
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "URL to the repository"
+                    },
+                    "packages": {
+                        "type": "array",
+                        "description": "List of packages in this repository",
+                        "items": {
+                            "type": "object",
+                            "required": ["name", "versions", "latest_version", "description", "category", "tags"],
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Package identifier",
+                                    "pattern": "^[a-z0-9_]+$"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "Human-readable description of the package"
+                                },
+                                "category": {
+                                    "type": "string",
+                                    "description": "Scientific domain or category"
+                                },
+                                "tags": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "description": "Keywords for discovery"
+                                },
+                                "versions": {
+                                    "type": "array",
+                                    "description": "Available versions of this package",
+                                    "items": {
+                                        "type": "object",
+                                        "required": ["version", "release_uri", "added_date"],
+                                        "properties": {
+                                            "version": {
+                                                "type": "string",
+                                                "description": "Semantic version of the package",
+                                                "pattern": "^\\d+(\\.\\d+)*$"
+                                            },
+                                            "release_uri": {
+                                                "type": "string",
+                                                "format": "uri",
+                                                "description": "URI to the release page for this version"
+                                            },
+                                            "base_version": {
+                                                "type": "string",
+                                                "description": "Version this differential is based on (null for first version)",
+                                                "pattern": "^\\d+(\\.\\d+)*$"
+                                            },
+                                            "hatch_dependencies_added": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "required": ["name"],
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "pattern": "^[a-z0-9_]+$",
+                                                            "description": "Name of the dependent package"
+                                                        },
+                                                        "version_constraint": {
+                                                            "type": "string", 
+                                                            "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                                                            "description": "Version constraint (e.g., '>=1.0.0', '==1.2.3')"
+                                                        }
+                                                    }
+                                                },
+                                                "description": "Hatch dependencies added since base_version"
+                                            },
+                                            "hatch_dependencies_removed": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "pattern": "^[a-z0-9_]+$",
+                                                    "description": "Name of a dependency that was removed from the previous version"
+                                                },
+                                                "description": "Names of dependencies removed since base_version"
+                                            },
+                                            "hatch_dependencies_modified": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "required": ["name"],
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "pattern": "^[a-z0-9_]+$",
+                                                            "description": "Name of the dependent package"
+                                                        },
+                                                        "version_constraint": {
+                                                            "type": "string", 
+                                                            "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                                                            "description": "Version constraint (e.g., '>=1.0.0', '==1.2.3')"
+                                                        }
+                                                    }
+                                                },
+                                                "description": "Dependencies with modified version constraints since base_version"
+                                            },
+                                            "python_dependencies_added": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "required": ["name"],
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "pattern": "^[a-z0-9-]+$",
+                                                            "description": "Name of the Python package"
+                                                        },
+                                                        "version_constraint": {
+                                                            "type": "string",
+                                                            "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                                                            "description": "Version constraint (e.g., '>=1.0.0', '==1.2.3')"
+                                                        },
+                                                        "package_manager": {
+                                                            "type": "string",
+                                                            "enum": ["pip", "conda"],
+                                                            "default": "pip",
+                                                            "description": "Package manager to use for installation"
+                                                        }
+                                                    }
+                                                },
+                                                "description": "Python dependencies added since base_version"
+                                            },
+                                            "python_dependencies_removed": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "pattern": "^[a-z0-9-]+$",
+                                                    "description": "Name of a Python dependency that was removed from the previous version"
+                                                },
+                                                "description": "Names of Python dependencies removed since base_version"
+                                            },
+                                            "python_dependencies_modified": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "required": ["name"],
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "pattern": "^[a-z0-9-]+$",
+                                                            "description": "Name of the Python package"
+                                                        },
+                                                        "version_constraint": {
+                                                            "type": "string",
+                                                            "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                                                            "description": "Version constraint (e.g., '>=1.0.0', '==1.2.3')"
+                                                        },
+                                                        "package_manager": {
+                                                            "type": "string",
+                                                            "enum": ["pip", "conda"],
+                                                            "default": "pip",
+                                                            "description": "Package manager to use for installation"
+                                                        }
+                                                    }
+                                                },
+                                                "description": "Python dependencies with modified version constraints since base_version"
+                                            },
+                                            "compatibility_changes": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "hatchling": {
+                                                        "type": "string",
+                                                        "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                                                        "description": "Changed version constraint for Hatchling compatibility"
+                                                    },
+                                                    "python": {
+                                                        "type": "string",
+                                                        "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                                                        "description": "Changed version constraint for Python compatibility"
+                                                    }
+                                                },
+                                                "description": "Changed compatibility constraints since base_version"
+                                            },
+                                            "added_date": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "description": "When this version was added to the registry"
+                                            }
+                                        }
+                                    }
+                                },
+                                "latest_version": {
+                                    "type": "string",
+                                    "description": "Latest version of the package",
+                                    "pattern": "^\\d+(\\.\\d+)*$" 
+                                }
+                            }
+                        }
+                    },
+                    "last_indexed": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "When this repository was last indexed"
+                    }
+                }
+            }
+        },
+        "stats": {
+            "type": "object",
+            "description": "Registry-wide statistics",
+            "properties": {
+                "total_packages": {
+                    "type": "integer",
+                    "description": "Total number of unique packages",
+                    "minimum": 0
+                },
+                "total_versions": {
+                    "type": "integer",
+                    "description": "Total number of package versions",
+                    "minimum": 0
+                }
+            }
+        }
+    },
+    "additionalProperties": false
+}

--- a/scripts/generate_gh_pages.sh
+++ b/scripts/generate_gh_pages.sh
@@ -64,7 +64,6 @@ cat > "$OUTPUT_DIR/index.html" << EOF
   <head>
     <meta charset="UTF-8">
     <title>Hatch Schemas</title>
-    <meta http-equiv="refresh" content="0; url=https://github.com/$REPO/releases">
     <style>
       body {
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -89,10 +88,7 @@ cat > "$OUTPUT_DIR/index.html" << EOF
       <div class="schema-versions">
 $(generate_schema_section "package")
         
-$(generate_schema_section "registry")
-      </div>
-      
-      <p>You are being redirected to the releases page...</p>
+$(generate_schema_section "registry")      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This pull request updates the JSON schema files for managing package metadata the package registry

### Update JSON Schemas:

* **Hatch Package Metadata Schema**:
  - The author field 
  - Updated the type field
  - Removed category
  - Updated license
  - Removed "artifacts" related fields and their nested schema definitions

* **CrackingShells Package Registry Schema**:
  - Update stats to be required
  - removed categoiry
  - Replaced "path" and "metadata_path" fields with a single "release_uri" field for better workflow integration
  - Removed "total_artifacts" from stats object properties

### Script Updates:

* **GitHub Pages Generation Script**:
  - Removed the meta-refresh tag redirecting to the releases page and adjusted the formatting of schema sections in the generated HTML file. [[1]](diffhunk://#diff-309ac7d9c30988fc7e2238a04c0671c732a7e67350ef6d3a8133cf4281eccb15L67) [[2]](diffhunk://#diff-309ac7d9c30988fc7e2238a04c0671c732a7e67350ef6d3a8133cf4281eccb15L92-R91)