### PR TITLE
Fixing schemas update to 1.1.0

### DIFF
--- a/package/v1.1.0/hatch_pkg_metadata_schema.json
+++ b/package/v1.1.0/hatch_pkg_metadata_schema.json
@@ -70,10 +70,10 @@
             "items": {
                 "type": "object",
                 "required": ["name", "type"],
-                "properties": {
-                    "type": {
+                "properties": {                    "type": {
                         "oneOf": [
                             {
+                                "type": "object",
                                 "properties": {
                                     "type": {
                                         "type": "string",
@@ -82,13 +82,13 @@
                                     },
                                     "path": {
                                         "type": "string",
-                                        "format": "path",
                                         "description": "If local, expecting a path to the root directory of the local package."
                                     }
                                 },
                                 "required": ["type", "path"]
                             },
                             {
+                                "type": "object",
                                 "properties": {
                                     "type": {
                                         "type": "string",


### PR DESCRIPTION
This pull request is the restart of #5 which was targeting the wrongly named branch `schemas-update`. Now that the branch has been renamed correctly, the validation workflow should trigger as expected.

The changes in this PR falls within the scope of https://github.com/CrackingShells/Hatch-Schemas/pull/3 which were an attempt at updating the schemas. Unfortunatly, the validation failed and broke the deployment. After the validation and deployment workflows were separated in https://github.com/CrackingShells/Hatch-Schemas/pull/4 to enable validation within PRs, we are now modifying the hatch_pkg_metadata_schema.json file to fix its structure.

### Schema fixing:
* Updated the type property to allow more flexible object definitions by adding additional nested type objects within the oneOf array.
* Removed the format: "path" which doesn't exist