### PR TITLE
Rework schema deployment workflow

### DIFF
--- a/.github/workflows/manual-schema-test.yml
+++ b/.github/workflows/manual-schema-test.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Create test package schema releases
         if: needs.prepare-test-data.outputs.pkg_versions != '[]'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2.2.2
         with:
           tag_name: schemas-package-${{ needs.prepare-test-data.outputs.highest_pkg_version }}-test
           name: "[TEST] Package Schema Release ${{ needs.prepare-test-data.outputs.highest_pkg_version }}"
@@ -162,7 +162,7 @@ jobs:
 
       - name: Create test registry schema releases  
         if: needs.prepare-test-data.outputs.registry_versions != '[]'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2.2.2
         with:
           tag_name: schemas-registry-${{ needs.prepare-test-data.outputs.highest_registry_version }}-test
           name: "[TEST] Registry Schema Release ${{ needs.prepare-test-data.outputs.highest_registry_version }}"


### PR DESCRIPTION
This pull request overhauls the `.github/workflows/manual-schema-test.yml` file to enhance the testing workflow for schema deployments. The changes aim to provide a more robust and flexible dry-run environment for testing schema validation and release processes without impacting production. Key updates include restructuring the workflow, introducing new inputs and outputs, and adding steps for preparing test data, validating schemas, and optionally creating test releases.

### Workflow Restructuring and Input Updates:
* Added new inputs such as `create_test_releases` to control whether test releases are created, and updated descriptions for existing inputs to clarify their purpose. Default schema versions were also updated to `v1.1.0`.
* Removed unused inputs like `test_schemas` and `deploy_test`, simplifying the workflow's configuration.

### Job and Step Enhancements:
* Replaced the `validate-schemas` job with a new `prepare-test-data` job that sets up test data and outputs key schema versions for downstream steps.
* Introduced a matrix strategy in the `validate-schemas` job to validate both package and registry schemas independently, using AJV for schema validation.

### Test Release Creation:
* Added a new `test-release-creation` job to optionally create pre-releases for package and registry schemas, using test-specific tags and metadata