### PR TITLE
[Update] Pkg v1.2.0

### DIFF
--- a/package/v1.2.0/hatch_pkg_metadata_schema.json
+++ b/package/v1.2.0/hatch_pkg_metadata_schema.json
@@ -76,8 +76,8 @@
                         "properties": {
                             "name": {
                                 "type": "string",
-                                "pattern": "^[a-z0-9_]+$",
-                                "description": "Name of the Hatch package"
+                                "pattern": "^[A-Za-z0-9_\\-./\\\\:]+$",
+                                "description": "Name of the Hatch package. The name can match an absolute or relative path for local packages. If it is a relative path, it is relative to the package's root directory. For remote packages (i.e. Hatch registry), a single name or, to remove ambiguity, the name prepended with the repository name, e.g., '<hatch-repo-name>:<package-name>'."
                             },
                             "version_constraint": {
                                 "type": "string",
@@ -96,8 +96,8 @@
                         "properties": {
                             "name": {
                                 "type": "string",
-                                "pattern": "^\\w+$",
-                                "description": "Name of the Python package"
+                                "pattern": "^[\\w\\-./\\\\]+$",
+                                "description": "Name of the Python package. The name can match an absolute or relative path to a directory to a local package. If it is a relative path, it is relative to the package's root directory."
                             },
                             "version_constraint": {
                                 "type": "string",


### PR DESCRIPTION
**Major**:
- This schema version was actually faulty.
- Compared to v1.1.0, it lost the capacity to support local or remote packages because some fields were removed
- But the patterns of the fields did not allow for all intended possible ways to add local or remote packages.
  - Hence, although this is technically an update, we are not bumping the version of the schema. We simply want to make it usable as the version 1.2.0