### PR TITLE
Package Schema v1.2.0 fix

### DIFF
--- a/package/v1.2.0/hatch_pkg_metadata_schema.json
+++ b/package/v1.2.0/hatch_pkg_metadata_schema.json
@@ -76,8 +76,8 @@
                         "properties": {
                             "name": {
                                 "type": "string",
-                                "pattern": "^[a-z0-9_]+$",
-                                "description": "Name of the Hatch package"
+                                "pattern": "^[A-Za-z0-9_\\-./\\\\:]+$",
+                                "description": "Name of the Hatch package. The name can match an absolute or relative path for local packages. If it is a relative path, it is relative to the package's root directory. For remote packages (i.e. Hatch registry), a single name or, to remove ambiguity, the name prepended with the repository name, e.g., '<hatch-repo-name>:<package-name>'."
                             },
                             "version_constraint": {
                                 "type": "string",
@@ -96,8 +96,8 @@
                         "properties": {
                             "name": {
                                 "type": "string",
-                                "pattern": "^\\w+$",
-                                "description": "Name of the Python package"
+                                "pattern": "^[\\w\\-./\\\\]+$",
+                                "description": "Name of the Python package. The name can match an absolute or relative path to a directory to a local package. If it is a relative path, it is relative to the package's root directory."
                             },
                             "version_constraint": {
                                 "type": "string",


### PR DESCRIPTION
This pull request updates the schema for Hatch and Python package metadata to allow more flexible naming conventions. The changes expand the allowed patterns for package names and provide detailed descriptions about how names can represent paths or include repository prefixes.

Updates to Hatch package metadata schema:

* [`package/v1.2.0/hatch_pkg_metadata_schema.json`](diffhunk://#diff-c0e238837f97f04bb4a343b05acfa0fb11dd78d08fd0eeb60a915d8d8e981f18L79-R80)