### PR TITLE
feat(schema): v2.0.0 extension schema — citations, provenance, schema_version

### DIFF
--- a/examples/v2.0.0/server_v2.0.0_example.json
+++ b/examples/v2.0.0/server_v2.0.0_example.json
@@ -1,0 +1,118 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "hatch_schema_version": "2.0.0",
+    "name": "io.github.example/weather-server",
+    "version": "1.0.14",
+    "description": "Example Hatch MCP server metadata showing citations, provenance, and all dependency types.",
+    "authors": [
+      {
+        "name": "Example Author",
+        "email": "author@example.org"
+      }
+    ],
+    "dependencies": {
+      "python": [
+        {
+          "name": "numpy",
+          "version_constraint": "==1.26.0",
+          "package_manager": "conda",
+          "channel": "conda-forge"
+        }
+      ],
+      "system": [
+        {
+          "name": "libgomp1",
+          "version_constraint": "==12.3.0",
+          "package_manager": "apt"
+        }
+      ],
+      "docker": [
+        {
+          "name": "ghcr.io/example/image",
+          "tag": "1.0.0",
+          "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        }
+      ],
+      "hatch": [
+        {
+          "name": "io.github.example/peer-pkg",
+          "version_constraint": "==0.1.0"
+        }
+      ]
+    },
+    "entry_point": {
+      "mcp_server": "server.py",
+      "hatch_mcp_server": "hatch_wrapper.py"
+    },
+    "tags": [
+      "meteorology",
+      "weather",
+      "prediction"
+    ],
+    "license": {
+      "name": "MIT",
+      "uri": "https://opensource.org/licenses/MIT"
+    },
+    "tools": [
+      {
+        "name": "get_weather",
+        "desc": "Return current weather for a requested location, fetched from Eumetnet."
+      },
+      {
+        "name": "get_forecast",
+        "desc": "Return a short-term forecast for a requested location."
+      }
+    ],
+    "documentation": "https://example.org/docs",
+    "provenance": {
+      "git_sha": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "build_env": "conda-lock"
+    },
+    "citations": [
+      {
+        "format": "doi",
+        "value": "10.1234/example",
+        "note": "primary paper"
+      },
+      {
+        "format": "arxiv",
+        "value": "2301.12345",
+        "note": "preprint"
+      },
+      {
+        "format": "pmid",
+        "value": "12345678",
+        "note": "method reference"
+      },
+      {
+        "format": "isbn",
+        "value": "9781234567897",
+        "note": "book reference"
+      },
+      {
+        "format": "url",
+        "value": "https://example.org/docs",
+        "note": "documentation"
+      },
+      {
+        "format": "bibtex",
+        "value": "@article{example2024,title={Example Paper},author={Author, Example},journal={Journal of Examples},year={2024}}",
+        "note": "dataset"
+      },
+      {
+        "format": "ris",
+        "value": "TY  - JOUR\nTI  - Example Paper\nAU  - Example, Author\nPY  - 2024\nER  -",
+        "note": "reference manager export"
+      },
+      {
+        "format": "csl-json",
+        "value": "{\"type\":\"article-journal\",\"title\":\"Example Paper\",\"author\":[{\"family\":\"Example\",\"given\":\"Author\"}],\"issued\":{\"date-parts\":[[2024]]}}",
+        "note": "machine-readable citation"
+      },
+      {
+        "format": "formatted",
+        "value": "Author et al. (2024). Example Paper. Journal of Examples.",
+        "note": "software used"
+      }
+    ]
+  }

--- a/examples/v2.0.0/server_v2.0.0_example.json
+++ b/examples/v2.0.0/server_v2.0.0_example.json
@@ -65,7 +65,7 @@
     ],
     "documentation": "https://example.org/docs",
     "provenance": {
-      "git_sha": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "git_sha": "a1b2c3d",
       "build_env": "conda-lock"
     },
     "citations": [

--- a/examples/v2.0.0/server_v2.0.0_invalid_example.json
+++ b/examples/v2.0.0/server_v2.0.0_invalid_example.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "hatch_schema_version": "2.0.0",
+    "name": "io.github.example/invalid-server",
+    "version": "1.0.14",
+    "description": "Invalid example of a Hatch MCP server metadata.",
+    "authors": [
+      {
+        "name": "Example Author",
+        "email": "author@example.org"
+      }
+    ],
+    "dependencies": {
+      "python": [
+        {
+          "name": "numpy",
+          "version_constraint": "==1.26.0",
+          "package_manager": "conda",
+          "channel": "conda-forge"
+        }
+      ],
+      "system": [
+        {
+          "name": "libgomp1",
+          "version_constraint": "==12.3.0",
+          "package_manager": "apt"
+        }
+      ],
+      "docker": [
+        {
+          "name": "ghcr.io/example/image",
+          "tag": "1.0.0",
+          "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        }
+      ],
+      "hatch": [
+        {
+          "name": "io.github.example/peer-pkg",
+          "version_constraint": "==0.1.0"
+        }
+      ]
+    },
+    "entry_point": {
+      "mcp_server": "server.py",
+      "hatch_mcp_server": "hatch_wrapper.py"
+    },
+    "tags": [
+      "meteorology",
+      "weather",
+      "prediction"
+    ],
+    "license": {
+      "name": "MIT",
+      "uri": "https://opensource.org/licenses/MIT"
+    },
+    "tools": [
+      {
+        "name": "get_weather",
+        "desc": "Return current weather for a requested location, fetched from Eumetnet."
+      },
+      {
+        "name": "get_forecast",
+        "desc": "Return a short-term forecast for a requested location."
+      }
+    ],
+    "documentation": "https://example.org/docs",
+    "provenance": {
+    },
+    "citations": [
+      {
+        "format": "doi",
+        "value": "10.1234/example",
+        "note": "primary paper"
+      },
+      {
+        "format": "sandwich",
+        "value": "2301.12345",
+        "note": "preprint"
+      }
+    ]
+  }

--- a/package/v2.0.0/hatch_pkg_metadata_schema.json
+++ b/package/v2.0.0/hatch_pkg_metadata_schema.json
@@ -173,14 +173,6 @@
                                 "pattern": "^sha256:[A-Fa-f0-9]{64}$",
                                 "description": "Immutable image digest (sha256)"
                             },
-                            "registry": {
-                                "type": "string",
-                                "enum": [
-                                    "dockerhub"
-                                ],
-                                "default": "dockerhub",
-                                "description": "Registry to pull the Docker image from"
-                            },
                             "tag": {
                                 "type": "string",
                                 "pattern": "^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$",

--- a/package/v2.0.0/hatch_pkg_metadata_schema.json
+++ b/package/v2.0.0/hatch_pkg_metadata_schema.json
@@ -263,6 +263,10 @@
         "provenance": {
             "type": "object",
             "description": "Reproducibility metadata describing the exact source and build environment",
+            "anyOf": [
+                { "required": ["git_sha"] },
+                { "required": ["build_env"] }
+              ],
             "properties": {
                 "git_sha": {
                     "type": "string",

--- a/package/v2.0.0/hatch_pkg_metadata_schema.json
+++ b/package/v2.0.0/hatch_pkg_metadata_schema.json
@@ -1,0 +1,413 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Hatch Package Metadata",
+    "description": "Schema for Hatch MCP Server package metadata with dual entry point support and conda channel support",
+    "type": "object",
+    "required": [
+        "hatch_schema_version",
+        "name",
+        "version",
+        "description",
+        "authors",
+        "entry_point"
+    ],
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "format": "uri",
+            "description": "JSON Schema reference URI"
+        },
+        "hatch_schema_version": {
+            "type": "string",
+            "description": "Version of the Hatch package schema used for this package metadata",
+            "pattern": "^2\\.0\\.0$"
+        },
+        "name": {
+            "type": "string",
+            "description": "Package name in reverse-DNS format with a single '/' separating namespace and server name (e.g., 'io.github.user/weather')",
+            "minLength": 3,
+            "maxLength": 200,
+            "pattern": "^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$"
+        },
+        "version": {
+            "type": "string",
+            "description": "Semantic version of the package",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$"
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "description": "Human-readable description of the package"
+        },
+        "authors": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "dependencies": {
+            "type": "object",
+            "properties": {
+                "hatch": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9_\\-./\\\\:]+$",
+                                "description": "Name of a Hatch package dependency. The name can match an absolute or relative path for local packages. If it is a relative path, it is relative to the package's root directory. For remote packages (i.e. packages on the official registry): reverse-DNS format with a single '/' separating namespace and server name (e.g., 'io.github.user/weather')"
+                            },
+                            "version_constraint": {
+                                "type": "string",
+                                "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                                "description": "Hatch version constraint for this dependency"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "description": "Hatch packages required"
+                },
+                "python": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "pattern": "^[\\w\\-./\\\\]+$",
+                                "description": "Name of the Python package. The name can match an absolute or relative path to a directory to a local package. If it is a relative path, it is relative to the package's root directory"
+                            },
+                            "version_constraint": {
+                                "type": "string",
+                                "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                                "description": "Version constraint for the Python package"
+                            },
+                            "package_manager": {
+                                "type": "string",
+                                "enum": [
+                                    "pip",
+                                    "conda"
+                                ],
+                                "default": "pip",
+                                "description": "Package manager to use for installation"
+                            },
+                            "channel": {
+                                "type": "string",
+                                "pattern": "^[a-zA-Z0-9_\\-]+$",
+                                "description": "Conda channel to use when package_manager is 'conda' (e.g., 'colomoto', 'conda-forge', 'bioconda')"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "description": "Python packages required"
+                },
+                "system": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9][A-Za-z0-9.+_-]*$",
+                                "description": "Name of a system package dependency"
+                            },
+                            "version_constraint": {
+                                "type": "string",
+                                "pattern": "^\\s*(==|>=|<=|!=)\\s*\\d+(\\.\\d+)*$",
+                                "description": "Version constraint for the system package"
+                            },
+                            "package_manager": {
+                                "type": "string",
+                                "enum": [
+                                    "apt"
+                                ],
+                                "default": "apt",
+                                "description": "Package manager to use for installation"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "description": "System packages required"
+                },
+                "docker": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "name",
+                            "digest"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9._/-]*[A-Za-z0-9])?$",
+                                "description": "Name of a Docker image dependency, allowing common repository/image naming patterns"
+                            },
+                            "digest": {
+                                "type": "string",
+                                "pattern": "^sha256:[A-Fa-f0-9]{64}$",
+                                "description": "Immutable image digest (sha256)"
+                            },
+                            "registry": {
+                                "type": "string",
+                                "enum": [
+                                    "dockerhub"
+                                ],
+                                "default": "dockerhub",
+                                "description": "Registry to pull the Docker image from"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$",
+                                "description": "Optional Docker image tag"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "description": "Docker images required"
+                }
+            },
+            "additionalProperties": false
+        },
+        "entry_point": {
+            "type": "object",
+            "description": "Dual entry point configuration for FastMCP server and HatchMCP wrapper",
+            "properties": {
+                "mcp_server": {
+                    "type": "string",
+                    "description": "FastMCP server implementation file",
+                    "pattern": "^[a-zA-Z0-9_][a-zA-Z0-9_.-]*\\.py$"
+                },
+                "hatch_mcp_server": {
+                    "type": "string",
+                    "description": "HatchMCP wrapper file",
+                    "pattern": "^[a-zA-Z0-9_][a-zA-Z0-9_.-]*\\.py$"
+                }
+            },
+            "required": [
+                "mcp_server",
+                "hatch_mcp_server"
+            ],
+            "additionalProperties": false
+        },
+        "tags": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "Keywords for discovery"
+        },
+        "license": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name or type of the license for this package"
+                },
+                "uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL to the license text. It can point to a file in the package or an external URL"
+                }
+            },
+            "additionalProperties": false
+        },
+        "tools": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "desc"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Function name exposed by the MCP server"
+                    },
+                    "desc": {
+                        "type": "string",
+                        "description": "Human-readable description of what the function does"
+                    }
+                },
+                "additionalProperties": false,
+                "description": "Metadata describing an individual MCP tool/function"
+            },
+            "description": "Functions exposed by the MCP server that can be invoked by clients"
+        },
+        "documentation": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the package documentation"
+        },
+        "provenance": {
+            "type": "object",
+            "description": "Reproducibility metadata describing the exact source and build environment",
+            "properties": {
+                "git_sha": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{7,40}$",
+                    "description": "Git commit SHA (short or full 40-character hash)"
+                },
+                "build_env": {
+                    "type": "string",
+                    "enum": [
+                        "conda-lock",
+                        "pip-compile",
+                        "manual"
+                    ],
+                    "description": "Dependency locking strategy used for the build"
+                }
+            },
+            "additionalProperties": false
+        },
+        "citations": {
+            "type": "array",
+            "description": "List of citations",
+            "items": {
+                "type": "object",
+                "required": [
+                    "format",
+                    "value"
+                ],
+                "properties": {
+                    "format": {
+                        "type": "string",
+                        "enum": [
+                            "doi",
+                            "arxiv",
+                            "pmid",
+                            "isbn",
+                            "url",
+                            "bibtex",
+                            "ris",
+                            "csl-json",
+                            "formatted"
+                        ],
+                        "description": "Citation format or identifier type"
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "Identifier or full citation text; interpretation depends on format"
+                    },
+                    "note": {
+                        "type": "string",
+                        "description": "Optional note about the citation"
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {
+                                "format": {
+                                    "const": "doi"
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "value": {
+                                    "pattern": "^10\\.\\d{4,}/\\S+$"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "format": {
+                                    "const": "arxiv"
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "value": {
+                                    "pattern": "^(\\d{4}\\.\\d{4,5}(v\\d+)?|https://arxiv\\.org/abs/.+)$"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "format": {
+                                    "const": "pmid"
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "value": {
+                                    "pattern": "^\\d+$"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "format": {
+                                    "const": "isbn"
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "value": {
+                                    "pattern": "^(97[89])?\\d{9}[\\dX]$"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "format": {
+                                    "const": "url"
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "value": {
+                                    "format": "uri"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "additionalProperties": false
+}

--- a/package/v2.0.0/hatch_pkg_metadata_schema.json
+++ b/package/v2.0.0/hatch_pkg_metadata_schema.json
@@ -5,9 +5,6 @@
     "type": "object",
     "required": [
         "hatch_schema_version",
-        "name",
-        "version",
-        "description",
         "authors",
         "entry_point"
     ],


### PR DESCRIPTION
- Relaxed "version_constraint" as a required field for dependencies: it's more user-friendly to program the newest version to be tried automatically
- Removed the "compatibility" field as a duplicate of "version_constraint"
- Standardized orthography and some descriptions
- Left the "tools" field in as a good place to describe the tools to the user, but changed "description" to "desc" in "tools"->"items" just in case the "description" field is hard-coded to be the unmodifiable meta-description of the fields themselves
- Implemented "citations", "hatch_schema_version" and "provenance" largely in the format proposed by Eliott
- Relaxed "license" and "tags" in requirements
- "author" -> "authors"; made "authors" stricter with "minItems": 1
- Reimplemented "name"
- Added "digest" to "docker" (left "version_constraint" as human-friendly alt.)
- Docker image `name`, as well as `system.name` are now less restrictive
- Added descriptions to "tools" and "documentation"
- Increased `description.maxLength` to `200`
- |version" now validates SemVer
- Docker `version_constraint` replaced with `tag`
- Added `additionalProperties: false` to nested objects where strictness is helpful`

Assumed the following fields would be programmatically picked up from the Official MCP metadata: 
  "name": "<reverse-dns>",
  "version": "...",
  "description": "..."
The rest of the fields should be transmitted inside `_meta`.`io.modelcontextprotocol.registry/publisher-provided`.